### PR TITLE
Don't set media.track.enabled, media.getusermedia.audiocapture.enabled or dom.paintWorklet.enabled

### DIFF
--- a/prefpicker/templates/browser-fuzzing.yml
+++ b/prefpicker/templates/browser-fuzzing.yml
@@ -238,9 +238,10 @@ pref:
   dom.min_background_timeout_value:
     default:
     - 4
+  # no plans to ship. https://bugzilla.mozilla.org/show_bug.cgi?id=1685228
   dom.paintWorklet.enabled:
     default:
-    - true
+    - null
   dom.payments.request.enabled:
     default:
     - true
@@ -484,9 +485,10 @@ pref:
   media.eme.hdcp-policy-check.enabled:
     default:
     - true
+  # no plans to ship. https://bugzilla.mozilla.org/show_bug.cgi?id=1685233
   media.getusermedia.audiocapture.enabled:
     default:
-    - true
+    - null
   media.getusermedia.browser.enabled:
     default:
     - true
@@ -509,9 +511,10 @@ pref:
   media.setsinkid.enabled:
     default:
     - true
+  # no plans to ship. https://bugzilla.mozilla.org/show_bug.cgi?id=1685235
   media.track.enabled:
     default:
-    - true
+    - null
   media.useAudioChannelAPI:
     default:
     - true


### PR DESCRIPTION
I've chosen `null` over `false` to clarify that the intention is not to change from the shipping state, and this will mean the pref value continues to follow shipping state, should that ever change.