### PR TITLE
Add apz.(non)wr.activate_all_scroll_frames

### DIFF
--- a/prefpicker/templates/browser-fuzzing.yml
+++ b/prefpicker/templates/browser-fuzzing.yml
@@ -13,6 +13,17 @@ pref:
   app.update.url.android:
     default:
     - ''
+  # https://bugzilla.mozilla.org/show_bug.cgi?id=1695957#c15
+  apz.nonwr.activate_all_scroll_frames:
+    default:
+    - false
+    - true
+  apz.wr.activate_all_scroll_frames:
+    default:
+    - null
+    webrender:
+    - false
+    - true
   browser.EULA.override:
     default:
     - true


### PR DESCRIPTION
By default `apz.nonwr.activate_all_scroll_frames` will be set randomly to either `true` or `false`.
When using `webrender` variant `apz.wr.activate_all_scroll_frames` will be  set randomly to either `true` or `false`.