### PR TITLE
Remove `media.useAudioChnanelAPI`

### DIFF
--- a/prefpicker/templates/browser-fuzzing.yml
+++ b/prefpicker/templates/browser-fuzzing.yml
@@ -527,9 +527,6 @@ pref:
   media.track.enabled:
     default:
     - null
-  media.useAudioChannelAPI:
-    default:
-    - true
   # no plans to ship. https://bugzilla.mozilla.org/show_bug.cgi?id=1685417
   media.webspeech.recognition.enable:
     default:


### PR DESCRIPTION
It hasn't been doing anything for years. I'm removing references to it in https://bugzilla.mozilla.org/show_bug.cgi?id=1706104, but it's never read, but is set.