### PR TITLE
Enable WebLocks API by default

### DIFF
--- a/prefpicker/templates/browser-fuzzing.yml
+++ b/prefpicker/templates/browser-fuzzing.yml
@@ -326,6 +326,9 @@ pref:
   dom.webgpu.enabled:
     default:
     - true
+  dom.weblocks.enabled:
+    default:
+    - true
   dom.window_print.fuzzing.block_while_printing:
     default:
     - true


### PR DESCRIPTION
Requested by @saschanaz.  This API will be enabled by default in nightly soon.  This will allow us to get a jump on fuzzing.