### PR TITLE
Add Writable Streams fuzzing 

### DIFF
--- a/prefpicker/templates/browser-fuzzing.yml
+++ b/prefpicker/templates/browser-fuzzing.yml
@@ -275,6 +275,9 @@ pref:
   dom.streams.writable_streams.enabled:
     default:
     - true
+  dom.streams.pipeTo.enabled:
+    default:
+    - true
   # pref copied from domfuzz
   dom.successive_dialog_time_limit:
     default:

--- a/prefpicker/templates/browser-fuzzing.yml
+++ b/prefpicker/templates/browser-fuzzing.yml
@@ -274,12 +274,14 @@ pref:
     - true
   dom.streams.writable_streams.enabled:
     default:
-    - true
     - false
+    writable-streams:
+    - true
   dom.streams.pipeTo.enabled:
     default:
-    - true
     - false
+    writable-streams:
+    - true
   # pref copied from domfuzz
   dom.successive_dialog_time_limit:
     default:
@@ -671,3 +673,4 @@ variant:
 - no-e10s
 - no-fission
 - vr
+- writable-streams

--- a/prefpicker/templates/browser-fuzzing.yml
+++ b/prefpicker/templates/browser-fuzzing.yml
@@ -272,6 +272,9 @@ pref:
   dom.serviceWorkers.testing.enabled:
     default:
     - true
+  dom.streams.writable_streams.enabled:
+    default:
+    - true
   # pref copied from domfuzz
   dom.successive_dialog_time_limit:
     default:

--- a/prefpicker/templates/browser-fuzzing.yml
+++ b/prefpicker/templates/browser-fuzzing.yml
@@ -274,12 +274,12 @@ pref:
     - true
   dom.streams.writable_streams.enabled:
     default:
-    - false
+    - null
     writable-streams:
     - true
   dom.streams.pipeTo.enabled:
     default:
-    - false
+    - null
     writable-streams:
     - true
   # pref copied from domfuzz

--- a/prefpicker/templates/browser-fuzzing.yml
+++ b/prefpicker/templates/browser-fuzzing.yml
@@ -275,9 +275,11 @@ pref:
   dom.streams.writable_streams.enabled:
     default:
     - true
+    - false
   dom.streams.pipeTo.enabled:
     default:
     - true
+    - false
   # pref copied from domfuzz
   dom.successive_dialog_time_limit:
     default:

--- a/prefpicker/templates/browser-fuzzing.yml
+++ b/prefpicker/templates/browser-fuzzing.yml
@@ -272,9 +272,6 @@ pref:
   dom.serviceWorkers.testing.enabled:
     default:
     - true
-  dom.streams.expose.ReadableStreamDefaultController:
-    default:
-    - true
   # pref copied from domfuzz
   dom.successive_dialog_time_limit:
     default:


### PR DESCRIPTION
Is there any way to indicate a dependency? 

It's not clear to me that fuzz tests where you `pipeTo && !writableStreams` make any sense... 