### PR TITLE
Add pre-commit hook for verifying template schema

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,6 +52,14 @@ repos:
   - repo: meta
     hooks:
       - id: check-useless-excludes
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: 0.13.0
+    hooks:
+      - id: check-jsonschema
+        name: "Check prefpicker template schema"
+        files: ^prefpicker/templates/
+        types: [ yaml ]
+        args: [ "--schemafile", "./prefpicker/templates/schema.json" ]
   - repo: local
     hooks:
       - id: pylint

--- a/prefpicker/templates/browser-fuzzing.yml
+++ b/prefpicker/templates/browser-fuzzing.yml
@@ -410,8 +410,8 @@ pref:
     variants:
       default:
       - false
-    vr:
-    - true
+      vr:
+      - true
   dom.vr.require-gesture:
     variants:
       default:

--- a/prefpicker/templates/schema.json
+++ b/prefpicker/templates/schema.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "description": "prefpicker template schema",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "pref": {
+      "type": "object",
+      "patternProperties": {
+        "^.*$": {
+          "additionalProperties": false,
+          "type": "object",
+          "properties": {
+            "variants": {
+              "type": "object",
+              "patternProperties": {
+                "^.*$": {
+                  "type": "array"
+                }
+              }
+            },
+            "review_on_close": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              }
+            }
+          }
+        }
+      }
+    },
+    "variant": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "required": [
+    "pref",
+    "variant"
+  ]
+}
+


### PR DESCRIPTION
Adds a JSON schema and pre-commit hook for validating the template files.  Do not land until https://github.com/MozillaSecurity/prefpicker/commits/updates is merged.