### PR TITLE
Remove gfx.e10s.font-list.shared entry

### DIFF
--- a/prefpicker/templates/browser-fuzzing.yml
+++ b/prefpicker/templates/browser-fuzzing.yml
@@ -548,11 +548,6 @@ pref:
     variants:
       default:
       - false
-  # bug 1514869 (requested by jkew)... TODO: this is now the default, remove it?
-  gfx.e10s.font-list.shared:
-    variants:
-      default:
-      - true
   gfx.offscreencanvas.enabled:
     variants:
       default:


### PR DESCRIPTION
`gfx.e10s.font-list.shared=true` is now the default.

See [Bug 1694174](https://bugzilla.mozilla.org/show_bug.cgi?id=1694174).