### PR TITLE
feat: enable dom.security.setHTML.enabled

### DIFF
--- a/src/prefpicker/templates/browser-fuzzing.yml
+++ b/src/prefpicker/templates/browser-fuzzing.yml
@@ -354,6 +354,12 @@ pref:
     variants:
       default:
       - true
+  dom.security.setHTML.enabled:
+    review_on_close:
+    - 1650370
+    variants:
+      default:
+      - true
   # needed when using MozAfterPaint event to control fuzzer
   dom.send_after_paint_to_content:
     variants:


### PR DESCRIPTION
setHTML functionality is behind a new pref: https://bugzilla.mozilla.org/show_bug.cgi?id=1805632