### PR TITLE
ci: fix semantic-release

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -43,7 +43,9 @@ deps =
 usedevelop = true
 
 [testenv:release]
-passenv = HOME PYPI_TOKEN
+passenv =
+    HOME
+    PYPI_TOKEN
 skip_install = true
 commands =
     semantic-release publish -v DEBUG


### PR DESCRIPTION
Another failure due to tox 4 update