### PR TITLE
fix: remove unnecessary pref layout.css.named-pages.enabled

### DIFF
--- a/src/prefpicker/templates/browser-fuzzing.yml
+++ b/src/prefpicker/templates/browser-fuzzing.yml
@@ -649,12 +649,6 @@ pref:
     variants:
       default:
       - true
-  layout.css.named-pages.enabled:
-    review_on_close:
-    - 1723234
-    variants:
-      default:
-      - true
   layout.css.overflow-clip-box.enabled:
     variants:
       default:


### PR DESCRIPTION
Closes https://github.com/MozillaSecurity/prefpicker/issues/76