### PR TITLE
feat: add dom.forms.datetime.others

### DIFF
--- a/src/prefpicker/templates/browser-fuzzing.yml
+++ b/src/prefpicker/templates/browser-fuzzing.yml
@@ -263,6 +263,10 @@ pref:
     variants:
       default:
       - true
+  dom.forms.datetime.others:
+    variants:
+      default:
+      - true
   dom.gamepad.extensions.lightindicator:
     variants:
       default:


### PR DESCRIPTION
Allows additional input elements to accept datetime values.