### PR TITLE
feat: add image.mem.max_legal_imgframe_size_kb=62500

### DIFF
--- a/src/prefpicker/templates/browser-fuzzing.yml
+++ b/src/prefpicker/templates/browser-fuzzing.yml
@@ -619,6 +619,10 @@ pref:
     variants:
       default:
       - 0
+  image.mem.max_legal_imgframe_size_kb:
+    variants:
+      default:
+      - 62500
   image.multithreaded_decoding.limit:
     variants:
       default:


### PR DESCRIPTION
Maximum size in kilobytes that we allow to allocate an imgFrame. This helps avoid OOMs when loading fuzzed images. Setting limit 62500=(4000x4000x4)/1024.