### PR TITLE
fix: update image related prefs

### DIFF
--- a/src/prefpicker/templates/browser-fuzzing.yml
+++ b/src/prefpicker/templates/browser-fuzzing.yml
@@ -621,28 +621,21 @@ pref:
     variants:
       default:
       - 1
+  # 0 - force running more complicated decode on demand path
   image.animated.decode-on-demand.threshold-kb:
     variants:
       default:
       - 0
-  image.avif.sequence.enabled:
-    review_on_close:
-    - 1813145
-    variants:
-      default:
-      - true
+      - null
   image.cache.size:
     variants:
       default:
       - 0
+      - null
   image.mem.max_legal_imgframe_size_kb:
     variants:
       default:
       - 62500
-  image.multithreaded_decoding.limit:
-    variants:
-      default:
-      - 1
   javascript.options.baselinejit.threshold:
     variants:
       default:


### PR DESCRIPTION
- image.animated.decode-on-demand.threshold-kb sometimes use default
- image.cache.size sometimes use default
- image.avif.sequence.enabled is now enabled by default
- image.multithreaded_decoding.limit no longer exists