### PR TITLE
Bug  1900661 - Add dom.fetchKeepalive.enabled to fuzzing prefs

### DIFF
--- a/src/prefpicker/templates/browser-fuzzing.yml
+++ b/src/prefpicker/templates/browser-fuzzing.yml
@@ -287,6 +287,10 @@ pref:
       default:
       - null
       - true
+  dom.fetchKeepalive.enabled
+    variants:
+      default:
+      - true
   dom.fetchObserver.enabled:
     variants:
       default:


### PR DESCRIPTION
Fetchkeepalive should be functional for non-worker fetch requests.