### PR TITLE
fix: webgl.colorspaces.prototype is now on by default

### DIFF
--- a/src/prefpicker/templates/browser-fuzzing.yml
+++ b/src/prefpicker/templates/browser-fuzzing.yml
@@ -1081,13 +1081,6 @@ pref:
     variants:
       default:
       - ''
-  webgl.colorspaces.prototype:
-    review_on_close:
-    - 1885491
-    variants:
-      default:
-      - false
-      - true
   webgl.enable-draft-extensions:
     variants:
       default:


### PR DESCRIPTION
Closes #126.