### PR TITLE
feat: remove layout.css.overflow-clip-box.enabled

### DIFF
--- a/src/prefpicker/templates/browser-fuzzing.yml
+++ b/src/prefpicker/templates/browser-fuzzing.yml
@@ -809,10 +809,6 @@ pref:
     variants:
       default:
       - true
-  layout.css.overflow-clip-box.enabled:
-    variants:
-      default:
-      - true
   layout.css.scroll-linked-animations.enabled:
     review_on_close:
     - 1676780


### PR DESCRIPTION
The feature this pref enables will never be enabled in Firefox.  See https://bugzilla.mozilla.org/show_bug.cgi?id=1936080.