### PR TITLE
feat: disable dom.navigation.webidl.enabled

### DIFF
--- a/src/prefpicker/templates/browser-fuzzing.yml
+++ b/src/prefpicker/templates/browser-fuzzing.yml
@@ -365,7 +365,7 @@ pref:
     - 1777171
     variants:
       default:
-      - true
+      - false
   dom.paintWorklet.enabled:
     review_on_close:
     - 1685228


### PR DESCRIPTION
Navigation API is still a work in progress, therefore there are lots of fuzzing bugs found which point to the unfinished implementation.

Let's disable fuzzing for Navigation API until the implementation is more mature.