### PR TITLE
feat: re-enable webgl.force-enabled

### DIFF
--- a/src/prefpicker/templates/browser-fuzzing.yml
+++ b/src/prefpicker/templates/browser-fuzzing.yml
@@ -1125,6 +1125,10 @@ pref:
     variants:
       default:
       - true
+  webgl.force-enabled:
+    variants:
+      default:
+      - true
   # Needed to prevent spamming of the webgl-xpcshell fuzzing target
   webgl.max-warnings-per-context:
     variants:


### PR DESCRIPTION
It appears that some checks are hidden behind `webgl.force-enabled`.