### PR TITLE
chore: remove dom.element.popover.enabled

### DIFF
--- a/src/prefpicker/templates/browser-fuzzing.yml
+++ b/src/prefpicker/templates/browser-fuzzing.yml
@@ -284,12 +284,6 @@ pref:
     variants:
       default:
       - false
-  dom.element.popover.enabled:
-    review_on_close:
-    - 1808823
-    variants:
-      default:
-      - true
   dom.experimental_forms:
     variants:
       default:


### PR DESCRIPTION
Set as default in https://bugzilla.mozilla.org/show_bug.cgi?id=1866993