### PR TITLE
fix: remove deprecated pref intl.accept_languages

### DIFF
--- a/src/prefpicker/templates/browser-fuzzing.yml
+++ b/src/prefpicker/templates/browser-fuzzing.yml
@@ -662,12 +662,6 @@ pref:
     variants:
       default:
       - 62500
-  intl.accept_languages:
-    review_on_close:
-    - 1760013
-    variants:
-      default:
-      - en-US, en
   javascript.options.baselinejit.threshold:
     variants:
       default:


### PR DESCRIPTION
Closes https://github.com/MozillaSecurity/prefpicker/issues/168.