### PR TITLE
fix: remove default pref javascript.options.use_js_microtask_queue

### DIFF
--- a/src/prefpicker/templates/browser-fuzzing.yml
+++ b/src/prefpicker/templates/browser-fuzzing.yml
@@ -756,12 +756,6 @@ pref:
       - 23
       - 24
       - 25
-  javascript.options.use_js_microtask_queue:
-    review_on_close:
-    - 1997192
-    variants:
-      default:
-      - true
   layers.acceleration.force-enabled:
     variants:
       default:


### PR DESCRIPTION
Closes https://github.com/MozillaSecurity/prefpicker/issues/171.