### PR TITLE
feat: temporarily enable dom navigation api

### DIFF
--- a/src/prefpicker/templates/browser-fuzzing.yml
+++ b/src/prefpicker/templates/browser-fuzzing.yml
@@ -359,7 +359,7 @@ pref:
     - 1777171
     variants:
       default:
-      - false
+      - true
   dom.paintWorklet.enabled:
     review_on_close:
     - 1685228


### PR DESCRIPTION
Temporarily enable dom.navigation.webidl.enabled until https://bugzilla.mozilla.org/show_bug.cgi?id=2013868 is resolved.