### PR TITLE
revert: "feat: always disable graphics driver blocklist"

### DIFF
--- a/src/prefpicker/templates/browser-fuzzing.yml
+++ b/src/prefpicker/templates/browser-fuzzing.yml
@@ -591,11 +591,6 @@ pref:
     variants:
       default:
       - false
-  # Always disable the blocklist
-  gfx.blocklist.all:
-    variants:
-      default:
-      - -1
   gfx.color_management.enablev4:
     variants:
       default:


### PR DESCRIPTION
This reverts commit f38a562cd88a93b2dd4d219e2535c394fcfd1844.

This appears to break debug builds.  Reverting for now.