### PR TITLE
ci: skip PyPI upload when dist is empty

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,7 @@ jobs:
           pipx run 'python-semantic-release~=10.0' -v publish
 
       - name: Upload to PyPI
+        if: hashFiles('dist/*') != ''
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           skip-existing: true


### PR DESCRIPTION
The OIDC migration dropped the guard that was in the old twine upload step (`if [[ ${#files[@]} -gt 0 ]]`). When PSR finds no releasable commits, `dist/` is empty and the publish action errors. Add an equivalent guard via `hashFiles`.